### PR TITLE
Set architecture based on CMAKE_GENERATOR_PLATFORM

### DIFF
--- a/Plugin/Build/CMakeLists.txt
+++ b/Plugin/Build/CMakeLists.txt
@@ -42,20 +42,23 @@ target_include_directories(${PLUGIN_NAME} PUBLIC ${GUI_BASE_DIR}/JuceLibraryCode
 #Libraries and compiler options
 if(MSVC)
 	set(GUI_BIN_DIR ${GUI_BASE_DIR}/Builds/VisualStudio2013)
-	if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+
+	if (CMAKE_GENERATOR_PLATFORM STREQUAL "x64")
 		set(GUI_BIN_DIR ${GUI_BIN_DIR}/x64)
 		set(CMAKE_LIBRARY_ARCHITECTURE "x64")
-	else()
+	elseif(CMAKE_GENERATOR_PLATFORM STREQUAL "Win32")
 		set(CMAKE_LIBRARY_ARCHITECTURE "x86")
+	else()
+		message(FATAL_ERROR "Unsupported generator platform ${CMAKE_GENERATOR_PLATFORM}")
 	endif()
 
-	target_link_directories(${PLUGIN_NAME} PUBLIC $<$<CONFIG:Debug>:${GUI_BIN_DIR}/Debug/bin>)
-	target_link_directories(${PLUGIN_NAME} PUBLIC $<$<CONFIG:Release>:${GUI_BIN_DIR}/Release/bin>)
-	target_link_libraries(${PLUGIN_NAME} open-ephys.lib)
+	set(GUI_BIN_DIR ${GUI_BIN_DIR}/$<IF:$<CONFIG:Debug>,Debug,Release>/bin)
+
+	target_link_libraries(${PLUGIN_NAME} ${GUI_BIN_DIR}/open-ephys.lib)
 	target_compile_options(${PLUGIN_NAME} PRIVATE /sdl-)
 	
-	install(TARGETS ${PLUGIN_NAME} RUNTIME DESTINATION ${GUI_BIN_DIR}/Debug/bin/plugins CONFIGURATIONS Debug)
-	install(TARGETS ${PLUGIN_NAME} RUNTIME DESTINATION ${GUI_BIN_DIR}/Release/bin/plugins CONFIGURATIONS Release)
+	install(TARGETS ${PLUGIN_NAME} RUNTIME DESTINATION ${GUI_BIN_DIR}/plugins)
+
 	set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../libs)
 elseif(LINUX)
 	set(GUI_BIN_DIR ${GUI_BASE_DIR}/Builds/Linux/build)

--- a/Plugin/Build/CMakeLists.txt
+++ b/Plugin/Build/CMakeLists.txt
@@ -42,14 +42,11 @@ target_include_directories(${PLUGIN_NAME} PUBLIC ${GUI_BASE_DIR}/JuceLibraryCode
 #Libraries and compiler options
 if(MSVC)
 	set(GUI_BIN_DIR ${GUI_BASE_DIR}/Builds/VisualStudio2013)
-
-	if (CMAKE_GENERATOR_PLATFORM STREQUAL "x64")
+	if (CMAKE_SIZEOF_VOID_P EQUAL 8)
 		set(GUI_BIN_DIR ${GUI_BIN_DIR}/x64)
 		set(CMAKE_LIBRARY_ARCHITECTURE "x64")
-	elseif(CMAKE_GENERATOR_PLATFORM STREQUAL "Win32")
-		set(CMAKE_LIBRARY_ARCHITECTURE "x86")
 	else()
-		message(FATAL_ERROR "Unsupported generator platform ${CMAKE_GENERATOR_PLATFORM}")
+		set(CMAKE_LIBRARY_ARCHITECTURE "x86")
 	endif()
 
 	set(GUI_BIN_DIR ${GUI_BIN_DIR}/$<IF:$<CONFIG:Debug>,Debug,Release>/bin)


### PR DESCRIPTION
This changes the target architecture on Windows to depend on the selected generator platform, rather than always going with the native one based on the size of `void*`. This allows testing the Win32 version while developing on a 64-bit machine.

For the VS2013 generator, you can specify the platform when calling `cmake` with the `-A` option, e.g.:

```
cmake -G "Visual Studio 12 2013" -A x64 ..
cmake -G "Visual Studio 12 2013" -A Win32 ..
```

I also changed the generator expression for the `bin` dir to use `Debug` for the `Debug` config and `Release` for all others, so the `MinSizeRel` and `RelWithDebInfo` configs should also work and install into the `Release` bin directory.

Finally, also resolves #1.